### PR TITLE
Rails5

### DIFF
--- a/lib/draper.rb
+++ b/lib/draper.rb
@@ -33,7 +33,7 @@ module Draper
       extend  Draper::HelperSupport
       extend  Draper::DecoratesAssigned
 
-      before_filter :activate_draper
+      before_action :activate_draper
     end
   end
 

--- a/lib/draper/railtie.rb
+++ b/lib/draper/railtie.rb
@@ -57,12 +57,6 @@ module Draper
       end
     end
 
-    console do
-      require 'action_controller/test_case'
-      ApplicationController.new.view_context
-      Draper::ViewContext.build
-    end
-
     rake_tasks do
       Dir[File.join(File.dirname(__FILE__),'tasks/*.rake')].each { |f| load f }
     end


### PR DESCRIPTION
Hey!

Here 2 helpers for the console:
1. As you know, `before_filter` is deprecated in rails 5. So, deprecation appeared on every console start;
2. I'm not sure about what the hell `view_context` is, but with it in the console block I receive an exception. After removing it all working as planned. I tested few decorators, all is working well.
